### PR TITLE
(chore): Use correct azure cli command

### DIFF
--- a/scripts/run_flyway_on_azure.sh
+++ b/scripts/run_flyway_on_azure.sh
@@ -55,8 +55,8 @@ az account set -s "${AZ_SUBSCRIPTION}"
 # shellcheck disable=SC2154
 printf "Subscription: %s\n" "${AZ_SUBSCRIPTION}"
 
-psql_server_name=$(az postgres server list -o tsv --query "[?contains(name,'$AZ_POSTGRES_RESOURCE_NAME')].{Name:name}" | head -1)
-psql_server_private_fqdn=$(az postgres server list -o tsv --query "[?contains(name,'$AZ_POSTGRES_RESOURCE_NAME')].{Name:fullyQualifiedDomainName}" | head -1)
+psql_server_name=$(az postgres flexible-server list -o tsv --query "[?contains(name,'$AZ_POSTGRES_RESOURCE_NAME')].{Name:name}" | head -1)
+psql_server_private_fqdn=$(az postgres flexible-server list -o tsv --query "[?contains(name,'$AZ_POSTGRES_RESOURCE_NAME')].{Name:fullyQualifiedDomainName}" | head -1)
 keyvault_name=$(az keyvault list -o tsv --query "[?contains(name,'$KV_NAME')].{Name:name}")
 
 # in widows, even if using cygwin, these variables will contain a landing \r character


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
* use `flexible-server` instead of `server`

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
SQL Migrations in CI/CD are broken because we use the wrong command to fetch actual database url. As we are connecting to a PostgresSQL with a _flexible_ plan, we must use `flexible-server` instead of just `server`.


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
